### PR TITLE
BugFix for Lepton Isolation

### DIFF
--- a/classes/DelphesClasses.cc
+++ b/classes/DelphesClasses.cc
@@ -111,7 +111,7 @@ TLorentzVector Tower::P4()
 
 Candidate::Candidate() :
   PID(0), Status(0), M1(-1), M2(-1), D1(-1), D2(-1),
-  IsolationVar(0),
+  IsolationVar(0), TrackIsolationVar(0),
   Charge(0), Mass(0.0),
   IsPU(0), IsRecoPU(0), IsEMCand(0), IsConstituent(0),
   BTag(0), TauTag(0), Eem(0.0), Ehad(0.0),
@@ -209,6 +209,7 @@ void Candidate::Copy(TObject &obj) const
   object.PID = PID;
   object.Status = Status;
   object.IsolationVar = IsolationVar;
+  object.TrackIsolationVar = TrackIsolationVar;
   object.M1 = M1;
   object.M2 = M2;
   object.D1 = D1;
@@ -286,6 +287,7 @@ void Candidate::Clear(Option_t* option)
   PID = 0;
   Status = 0;
   IsolationVar =0.;
+  TrackIsolationVar =0.;
   M1 = -1; M2 = -1; D1 = -1; D2 = -1;
   Charge = 0;
   Mass = 0.0;

--- a/classes/DelphesClasses.h
+++ b/classes/DelphesClasses.h
@@ -438,6 +438,7 @@ public:
 
   Float_t Mass;
   Float_t IsolationVar;
+  Float_t TrackIsolationVar;
 
   
   Int_t IsPU;

--- a/modules/IsoTrackFilter.cc
+++ b/modules/IsoTrackFilter.cc
@@ -194,7 +194,7 @@ void IsoTrackFilter::IsoTrackSelector(std::vector< TIterator * >& fAllInputList,
 
     ratio = sum/candidateMomentum.Pt();
 
-    candidate->IsolationVar = ratio;
+    candidate->TrackIsolationVar = ratio;
 
     if (IsEM) candidate->IsEMCand = 1;
 

--- a/modules/TreeWriter.cc
+++ b/modules/TreeWriter.cc
@@ -478,7 +478,7 @@ void TreeWriter::ProcessIsoTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->Eta = eta;
     entry->Phi = momentum.Phi();
     entry->PT = pt;
-    entry->IsolationVar = candidate->IsolationVar;
+    entry->IsolationVar = candidate->TrackIsolationVar;
 
     entry->Charge = candidate->Charge;
     entry->IsEMCand = candidate->IsEMCand;


### PR DESCRIPTION
It was found that the lepton isolation are changed to >1 instead of
<0.4 etc in the samples. This is because the Isolationvar got overwritten in
the IsoTrackFilter module, which calculated the isolation use PV tracks only.

To fix this problem, I added a new variable TrackIsolationVar to the Candidate
class to store the track isolation in the IsoTrackFilter module. The TreeWriter 
for IsoTrack will still store the TrackIsolationVar into Isolationvar.
